### PR TITLE
Add weekly meal plan generation and views

### DIFF
--- a/AlefNutrition_Render_Ready/templates/admin.html
+++ b/AlefNutrition_Render_Ready/templates/admin.html
@@ -13,6 +13,7 @@
         </div>
         <div style="display:flex; gap:8px; flex-wrap:wrap">
           <a class="btn ghost" href="{{ url_for('admin_report', pid=p.id) }}">Descargar PDF</a>
+          <a class="btn primary" href="{{ url_for('admin_plan', pid=p.id) }}">Menú semanal</a>
         </div>
       </div>
 

--- a/AlefNutrition_Render_Ready/templates/dashboard.html
+++ b/AlefNutrition_Render_Ready/templates/dashboard.html
@@ -26,6 +26,11 @@
   </div>
 
   <div class="card section">
+    <h3>Mi menú</h3>
+    <a class="btn ghost" href="{{ url_for('patient_plan') }}">Ver mi menú semanal</a>
+  </div>
+
+  <div class="card section">
     <h3>Subir comida (foto)</h3>
     <form method="post" enctype="multipart/form-data">
       <div class="field"><input type="file" name="meal_photo" accept="image/*" required></div>

--- a/AlefNutrition_Render_Ready/templates/plan.html
+++ b/AlefNutrition_Render_Ready/templates/plan.html
@@ -1,0 +1,39 @@
+{% extends "base.html" %}
+{% block content %}
+<section class="container section">
+  <h2>Menú semanal — {{ patient.name or patient.email }}</h2>
+  <p class="lead">Objetivo diario: TDEE {{ calc.tdee }} kcal · Prot {{ calc.p }} g · Grasa {{ calc.f }} g · CHO {{ calc.c }} g</p>
+
+  {% if who == 'admin' %}
+  <form method="post" class="form card">
+    <p>Genera/actualiza un menú de 7 días en base al TDEE y macros del paciente.</p>
+    <button class="btn primary" type="submit">Generar nuevo menú</button>
+  </form>
+  {% endif %}
+
+  {% if plan %}
+    {% for day in plan.days %}
+      <div class="card" style="margin-top:14px">
+        <h3>Día {{ loop.index }}</h3>
+        <table class="table">
+          <tr><th>Tiempo</th><th>Comida</th><th>Porción</th><th>Kcal</th><th>P</th><th>C</th><th>G</th></tr>
+          {% for slot in ["desayuno","comida","cena","snack"] %}
+            {% set it = day[slot] %}
+            <tr>
+              <td>{{ slot|capitalize }}</td>
+              <td>{{ it.name }}</td>
+              <td>{{ it.portion }}x</td>
+              <td>{{ it.kcal }}</td>
+              <td>{{ it.prot }}</td>
+              <td>{{ it.carb }}</td>
+              <td>{{ it.fat }}</td>
+            </tr>
+          {% endfor %}
+        </table>
+      </div>
+    {% endfor %}
+  {% else %}
+    <div class="card"><p>No hay menú guardado aún.</p></div>
+  {% endif %}
+</section>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add meal plan persistence with a new `mealplans` table and helper utilities to build week menus
- expose admin and patient routes and template to generate and view weekly menus based on calculated macros
- link the new menu views from the admin panel and patient dashboard

## Testing
- python -m compileall AlefNutrition_Render_Ready

------
https://chatgpt.com/codex/tasks/task_e_68e43f5aace483288de81de5a032a1f0