### PR TITLE
Fix weight logging bug and harden uploads

### DIFF
--- a/AlefNutrition_Render_Ready/templates/admin.html
+++ b/AlefNutrition_Render_Ready/templates/admin.html
@@ -37,7 +37,9 @@
           <h4>Últimas comidas</h4>
           <div class="meals">
             {% for m in row.meals %}
-              <img src="/{{ m.image_path }}" alt="meal">
+              {% if m.image_path %}
+                <img src="{{ url_for('uploaded_file', filename=m.image_path.split('uploads/',1)[-1]) }}" alt="meal">
+              {% endif %}
             {% endfor %}
           </div>
         </div>

--- a/AlefNutrition_Render_Ready/templates/dashboard.html
+++ b/AlefNutrition_Render_Ready/templates/dashboard.html
@@ -11,9 +11,12 @@
     <div class="card">
       <h3>Registrar peso</h3>
       <form method="post">
-        <input type="hidden" name="weight_entry" value="1">
+        <input type="hidden" name="weight_flag" value="1">
         <div class="grid2">
-          <div class="field"><label>Peso (kg)</label><input name="weight_entry" type="number" step="0.1" required></div>
+          <div class="field">
+            <label>Peso (kg)</label>
+            <input name="weight_kg" type="number" step="0.1" min="20" max="400" required>
+          </div>
         </div>
         <button class="btn primary">Guardar</button>
       </form>
@@ -40,7 +43,9 @@
     <div class="meals section">
       {% for m in meals %}
         <div>
-          <img src="/{{ m.image_path }}" alt="comida">
+          {% if m.image_path %}
+            <img src="{{ url_for('uploaded_file', filename=m.image_path.split('uploads/',1)[-1]) }}" alt="comida">
+          {% endif %}
           <div class="status">{{ m.created_at[:16].replace('T',' ') }} — {{ m.comment or '' }}</div>
         </div>
       {% endfor %}

--- a/AlefNutrition_Render_Ready/templates/plan.html
+++ b/AlefNutrition_Render_Ready/templates/plan.html
@@ -4,6 +4,12 @@
   <h2>Menú semanal — {{ patient.name or patient.email }}</h2>
   <p class="lead">Objetivo diario: TDEE {{ calc.tdee }} kcal · Prot {{ calc.p }} g · Grasa {{ calc.f }} g · CHO {{ calc.c }} g</p>
 
+  <div class="card">
+    <strong>Objetivo por tiempo:</strong>
+    <div class="status">Desayuno 25% · Comida 35% · Cena 25% · Snack 15% del TDEE.</div>
+    <div class="status">La “porción ×f” es cuántas porciones base aproximadas comer.</div>
+  </div>
+
   {% if who == 'admin' %}
   <form method="post" class="form card">
     <p>Genera/actualiza un menú de 7 días en base al TDEE y macros del paciente.</p>
@@ -16,13 +22,13 @@
       <div class="card" style="margin-top:14px">
         <h3>Día {{ loop.index }}</h3>
         <table class="table">
-          <tr><th>Tiempo</th><th>Comida</th><th>Porción</th><th>Kcal</th><th>P</th><th>C</th><th>G</th></tr>
+          <tr><th>Tiempo</th><th>Comida</th><th>Porción sugerida</th><th>Kcal</th><th>P</th><th>C</th><th>G</th></tr>
           {% for slot in ["desayuno","comida","cena","snack"] %}
             {% set it = day[slot] %}
             <tr>
               <td>{{ slot|capitalize }}</td>
               <td>{{ it.name }}</td>
-              <td>{{ it.portion }}x</td>
+              <td>{{ '%.2f'|format(it.portion) }}× (ajustada)</td>
               <td>{{ it.kcal }}</td>
               <td>{{ it.prot }}</td>
               <td>{{ it.carb }}</td>


### PR DESCRIPTION
## Summary
- fix the dashboard weight form/handler collision so patient weigh-ins save the entered value
- round meal plan portions to clearer 0.25 increments and explain the serving guidance in the UI
- serve uploaded images safely while hardening storage paths, sqlite access, response headers, and image validation

## Testing
- python -m compileall AlefNutrition_Render_Ready

------
https://chatgpt.com/codex/tasks/task_e_68e47b11b2a083289b06388915b4e95d